### PR TITLE
Change plugin display name

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
   <id>com.dropbox.plugins.mypy_plugin</id>
-  <name>Mypy Official</name>
+  <name>Mypy (Official)</name>
   <version>0.3.0</version>
   <vendor url="https://github.com/dropbox/mypy-PyCharm-plugin">Dropbox Mypy Team</vendor>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
   <id>com.dropbox.plugins.mypy_plugin</id>
-  <name>Dropbox mypy plugin</name>
+  <name>Mypy Official</name>
   <version>0.3.0</version>
   <vendor url="https://github.com/dropbox/mypy-PyCharm-plugin">Dropbox Mypy Team</vendor>
 


### PR DESCRIPTION
This is in preparation to publishing this on JetBrains repo.

Note:
* The word "plugin" should not appear in the display name
* Each display name should be unique there, and "Mypy" is already taken (and the author prefers to keep it)
* This will be considered as an update for existing installs, since the plugins are identified by `id` in PyCharm

@JukkaL @msullivan @gvanrossum 
I think I discussed this with, but just to double-check I tag you here.

